### PR TITLE
feat(profile): add display name editing, update personal info & goals…

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -7,6 +7,22 @@
         { "fieldPath": "isEnabled", "order": "ASCENDING" },
         { "fieldPath": "nameLower", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "weights",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "date", "order": "DESCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "diaryEntries",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "date", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/lib/core/health/health_repository.dart
+++ b/lib/core/health/health_repository.dart
@@ -14,5 +14,12 @@ abstract class HealthRepository {
   /// Get total active energy burned (kcal) for today.
   /// Returns 0.0 if no data is available or if there's an error.
   Future<double> getTodayActiveCalories();
+
+  /// Get total steps for a date range (from startDate to endDate, inclusive).
+  /// Returns 0 if no data is available or if there's an error.
+  Future<int> getStepsForDateRange({
+    required DateTime startDate,
+    required DateTime endDate,
+  });
 }
 

--- a/lib/core/health/health_repository_health_plugin.dart
+++ b/lib/core/health/health_repository_health_plugin.dart
@@ -107,5 +107,39 @@ class HealthRepositoryHealthPlugin implements HealthRepository {
     debugPrint('[HealthRepo] getTodayActiveCalories() called - returning 0.0 (calories not synced from Health Connect)');
     return 0.0;
   }
+
+  @override
+  Future<int> getStepsForDateRange({
+    required DateTime startDate,
+    required DateTime endDate,
+  }) async {
+    debugPrint('[HealthRepo] ▶ getStepsForDateRange() called from $startDate to $endDate');
+    
+    try {
+      // Normalize startDate to midnight
+      final start = DateTime(startDate.year, startDate.month, startDate.day);
+      // Normalize endDate to end of day (23:59:59)
+      final end = DateTime(endDate.year, endDate.month, endDate.day, 23, 59, 59);
+      
+      debugPrint('[HealthRepo] Querying steps from $start to $end');
+      
+      final steps = await _health.getTotalStepsInInterval(start, end);
+      final stepCount = steps ?? 0;
+      
+      debugPrint('[HealthRepo] ✅ Steps retrieved for date range: $stepCount');
+      
+      return stepCount;
+    } catch (e, stackTrace) {
+      debugPrint('[HealthRepo] ❌ Error getting steps for date range: $e');
+      debugPrint('[HealthRepo] Stack trace: $stackTrace');
+      developer.log(
+        'Error getting steps for date range',
+        name: 'HealthRepo',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      return 0;
+    }
+  }
 }
 

--- a/lib/data/firebase/profile_repository.dart
+++ b/lib/data/firebase/profile_repository.dart
@@ -551,4 +551,37 @@ class ProfileRepository {
       rethrow;
     }
   }
+
+  /// Update the user document's displayName field
+  /// 
+  /// This updates the displayName in users/{uid} document.
+  /// This is separate from the profile nickname field.
+  /// 
+  /// [uid] - User ID
+  /// [displayName] - New display name (will be trimmed)
+  Future<void> updateUserDisplayName(String uid, String displayName) async {
+    debugPrint(
+      '[ProfileRepository] 🔵 Updating displayName for uid=$uid',
+    );
+
+    try {
+      final trimmedName = displayName.trim();
+      
+      // Update the user document
+      await _firestore.collection('users').doc(uid).set({
+        'displayName': trimmedName,
+      }, SetOptions(merge: true));
+
+      debugPrint(
+        '[ProfileRepository] ✅ Successfully updated displayName for uid=$uid',
+      );
+    } catch (e, stackTrace) {
+      debugPrint(
+        '[ProfileRepository] 🔥 updateUserDisplayName FAILED for uid=$uid',
+      );
+      debugPrint('[ProfileRepository] Error: $e');
+      debugPrint('[ProfileRepository] Stack trace: $stackTrace');
+      rethrow;
+    }
+  }
 }

--- a/lib/features/home/domain/statistics_models.dart
+++ b/lib/features/home/domain/statistics_models.dart
@@ -1,0 +1,175 @@
+/// Models for statistics data used in report screens
+
+/// Nutrition statistics for a time period
+class NutritionStats {
+  final double totalCalories;
+  final double totalProtein;
+  final double totalCarbs;
+  final double totalFat;
+  final int entryCount;
+  final double? targetCalories; // Optional target for comparison
+
+  NutritionStats({
+    required this.totalCalories,
+    required this.totalProtein,
+    required this.totalCarbs,
+    required this.totalFat,
+    required this.entryCount,
+    this.targetCalories,
+  });
+
+  /// Progress towards calorie target (0.0 to 1.0, or >1.0 if exceeded)
+  double get progress => targetCalories != null && targetCalories! > 0
+      ? (totalCalories / targetCalories!).clamp(0, double.infinity)
+      : 0.0;
+
+  /// Whether calorie target was met or exceeded
+  bool get isTargetMet => targetCalories != null && totalCalories >= targetCalories!;
+
+  /// Calories remaining until target (0 if exceeded)
+  double get remaining => targetCalories != null
+      ? (targetCalories! - totalCalories).clamp(0, double.infinity)
+      : 0.0;
+
+  /// Calories exceeded beyond target (0 if not exceeded)
+  double get exceeded => targetCalories != null
+      ? (totalCalories - targetCalories!).clamp(0, double.infinity)
+      : 0.0;
+}
+
+/// Workout statistics for a time period
+class WorkoutStats {
+  final double totalCaloriesBurned;
+  final double totalDurationMinutes;
+  final int workoutCount;
+  final List<String> exerciseNames; // Unique exercise names
+
+  WorkoutStats({
+    required this.totalCaloriesBurned,
+    required this.totalDurationMinutes,
+    required this.workoutCount,
+    required this.exerciseNames,
+  });
+
+  /// Total duration in hours
+  double get totalDurationHours => totalDurationMinutes / 60.0;
+
+  /// Average calories burned per workout
+  double get avgCaloriesPerWorkout =>
+      workoutCount > 0 ? totalCaloriesBurned / workoutCount : 0.0;
+
+  /// Average duration per workout in minutes
+  double get avgDurationPerWorkout =>
+      workoutCount > 0 ? totalDurationMinutes / workoutCount : 0.0;
+}
+
+/// Steps statistics for a time period
+class StepsStats {
+  final int totalSteps;
+  final int? targetSteps; // Optional daily step goal
+
+  StepsStats({
+    required this.totalSteps,
+    this.targetSteps,
+  });
+
+  /// Progress towards step target (0.0 to 1.0, or >1.0 if exceeded)
+  double get progress => targetSteps != null && targetSteps! > 0
+      ? (totalSteps / targetSteps!).clamp(0, double.infinity)
+      : 0.0;
+
+  /// Whether step target was met or exceeded
+  bool get isTargetMet => targetSteps != null && totalSteps >= targetSteps!;
+
+  /// Steps remaining until target (0 if exceeded)
+  int get remaining => targetSteps != null
+      ? (targetSteps! - totalSteps).clamp(0, targetSteps!)
+      : 0;
+
+  /// Steps exceeded beyond target (0 if not exceeded)
+  int get exceeded => targetSteps != null
+      ? (totalSteps - targetSteps!).clamp(0, totalSteps)
+      : 0;
+}
+
+/// Weight statistics for a time period
+class WeightStats {
+  final double? latestWeight;
+  final double? earliestWeight;
+  final double? weightChange; // Positive = gain, negative = loss
+  final int entryCount;
+  final List<WeightPoint> weightHistory; // For charting
+  final double? targetWeight; // Goal weight from profile
+  final double? previousPeriodWeight; // Weight from previous period (yesterday, last week, last month)
+
+  WeightStats({
+    this.latestWeight,
+    this.earliestWeight,
+    this.weightChange,
+    required this.entryCount,
+    required this.weightHistory,
+    this.targetWeight,
+    this.previousPeriodWeight,
+  });
+
+  /// Whether weight increased
+  bool get isWeightGain => weightChange != null && weightChange! > 0;
+
+  /// Whether weight decreased
+  bool get isWeightLoss => weightChange != null && weightChange! < 0;
+
+  /// Whether weight stayed the same (within 0.1 kg tolerance)
+  bool get isWeightMaintained => weightChange != null && weightChange!.abs() < 0.1;
+
+  /// Change vs previous period (e.g., vs yesterday)
+  double? get changeVsPrevious => latestWeight != null && previousPeriodWeight != null
+      ? latestWeight! - previousPeriodWeight!
+      : null;
+
+  /// Progress towards goal weight (0.0 to 1.0)
+  /// Returns null if targetWeight is not set or if current weight is already at/over goal
+  double? get progressToGoal {
+    if (latestWeight == null || targetWeight == null) return null;
+    
+    // For weight loss goal: progress = (startWeight - currentWeight) / (startWeight - targetWeight)
+    // For weight gain goal: progress = (currentWeight - startWeight) / (targetWeight - startWeight)
+    // For maintain goal: progress = 1.0 if within 0.5 kg of target
+    
+    // We need start weight to calculate progress, but we can estimate from earliestWeight
+    final startWeight = earliestWeight ?? latestWeight;
+    if (startWeight == null) return null;
+    
+    final diff = (targetWeight! - startWeight).abs();
+    if (diff < 0.1) return 1.0; // Already at goal
+    
+    if (targetWeight! < startWeight) {
+      // Weight loss goal
+      final progress = (startWeight - latestWeight!) / (startWeight - targetWeight!);
+      return progress.clamp(0.0, 1.0);
+    } else {
+      // Weight gain goal
+      final progress = (latestWeight! - startWeight) / (targetWeight! - startWeight);
+      return progress.clamp(0.0, 1.0);
+    }
+  }
+
+  /// Trend label in Vietnamese
+  String get trendLabel {
+    if (weightChange == null) return 'Chưa có dữ liệu';
+    if (isWeightMaintained) return 'Duy trì';
+    if (isWeightGain) return 'Tăng cân';
+    return 'Giảm cân';
+  }
+}
+
+/// A single weight data point for charting
+class WeightPoint {
+  final DateTime date;
+  final double weight;
+
+  WeightPoint({
+    required this.date,
+    required this.weight,
+  });
+}
+

--- a/lib/features/home/presentation/pages/goals_screen.dart
+++ b/lib/features/home/presentation/pages/goals_screen.dart
@@ -1,0 +1,223 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:calories_app/shared/state/auth_providers.dart';
+
+/// Goals Screen
+/// 
+/// Displays user's goal-related information from their profile:
+/// - Main goal type (lose/maintain/gain weight)
+/// - Target weight
+/// - Weekly weight change rate
+/// - Daily calorie goal
+/// 
+/// Navigation: Accessed from Settings page "Mục tiêu của tôi"
+class GoalsScreen extends ConsumerWidget {
+  const GoalsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final user = FirebaseAuth.instance.currentUser;
+
+    // Check if user is signed in
+    if (user == null) {
+      return Scaffold(
+        backgroundColor: const Color(0xFFF8F9FA),
+        appBar: AppBar(
+          backgroundColor: Colors.white,
+          elevation: 0,
+          title: const Text(
+            'Mục tiêu của tôi',
+            style: TextStyle(
+              color: Colors.black87,
+              fontSize: 20,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back, color: Colors.black87),
+            onPressed: () => Navigator.of(context).pop(),
+          ),
+        ),
+        body: const Center(
+          child: Text(
+            'Bạn chưa đăng nhập',
+            style: TextStyle(
+              fontSize: 16,
+              color: Colors.grey,
+            ),
+          ),
+        ),
+      );
+    }
+
+    // Watch profile data
+    final profileAsync = ref.watch(currentUserProfileProvider);
+
+    return Scaffold(
+      backgroundColor: const Color(0xFFF8F9FA),
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        elevation: 0,
+        title: const Text(
+          'Mục tiêu của tôi',
+          style: TextStyle(
+            color: Colors.black87,
+            fontSize: 20,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back, color: Colors.black87),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+      ),
+      body: profileAsync.when(
+        data: (profile) {
+          if (profile == null) {
+            return const Center(
+              child: Padding(
+                padding: EdgeInsets.all(24.0),
+                child: Text(
+                  'Chưa có dữ liệu mục tiêu',
+                  style: TextStyle(
+                    fontSize: 16,
+                    color: Colors.grey,
+                  ),
+                ),
+              ),
+            );
+          }
+
+          return ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              _buildInfoCard(
+                context,
+                label: 'Mục tiêu chính',
+                value: profile.goalTypeLabel,
+              ),
+              const SizedBox(height: 8),
+              _buildInfoCard(
+                context,
+                label: 'Cân nặng mục tiêu',
+                value: profile.targetWeight != null
+                    ? '${profile.targetWeight!.toStringAsFixed(1)} kg'
+                    : '-',
+              ),
+              const SizedBox(height: 8),
+              _buildInfoCard(
+                context,
+                label: 'Tốc độ thay đổi',
+                value: profile.weeklyDeltaKg != null
+                    ? '${profile.weeklyDeltaKg!.toStringAsFixed(2)} kg/tuần'
+                    : '-',
+              ),
+              const SizedBox(height: 8),
+              _buildInfoCard(
+                context,
+                label: 'Mục tiêu calo mỗi ngày',
+                value: profile.targetKcal != null
+                    ? '${profile.targetKcal!.toStringAsFixed(0)} kcal'
+                    : '-',
+              ),
+              if (profile.goalDate != null) ...[
+                const SizedBox(height: 8),
+                _buildInfoCard(
+                  context,
+                  label: 'Ngày đạt mục tiêu',
+                  value: _formatGoalDate(profile.goalDate!),
+                ),
+              ],
+            ],
+          );
+        },
+        loading: () => const Center(
+          child: CircularProgressIndicator(),
+        ),
+        error: (error, stack) => Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24.0),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(
+                  Icons.error_outline,
+                  size: 48,
+                  color: Colors.red[400],
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  'Lỗi tải dữ liệu',
+                  style: TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.red[700],
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  'Đã xảy ra lỗi, vui lòng thử lại sau.\nChi tiết: ${error.toString()}',
+                  style: TextStyle(
+                    fontSize: 14,
+                    color: Colors.grey[600],
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildInfoCard(
+    BuildContext context, {
+    required String label,
+    required String value,
+  }) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.05),
+            blurRadius: 10,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              label,
+              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                    color: Colors.grey[700],
+                  ),
+            ),
+            Text(
+              value,
+              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: Colors.black87,
+                  ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _formatGoalDate(DateTime date) {
+    final day = date.day.toString().padLeft(2, '0');
+    final month = date.month.toString().padLeft(2, '0');
+    final year = date.year.toString();
+    return '$day/$month/$year';
+  }
+}
+

--- a/lib/features/home/presentation/pages/personal_info_screen.dart
+++ b/lib/features/home/presentation/pages/personal_info_screen.dart
@@ -1,0 +1,226 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:calories_app/shared/state/auth_providers.dart';
+
+/// Personal Info Screen
+/// 
+/// Displays user's personal information from their profile:
+/// - Full name
+/// - Gender
+/// - Date of birth
+/// - Height
+/// - Current weight
+/// - Activity level
+/// 
+/// Navigation: Accessed from Settings page "Thông tin cá nhân"
+class PersonalInfoScreen extends ConsumerWidget {
+  const PersonalInfoScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final user = FirebaseAuth.instance.currentUser;
+
+    // Check if user is signed in
+    if (user == null) {
+      return Scaffold(
+        backgroundColor: const Color(0xFFF8F9FA),
+        appBar: AppBar(
+          backgroundColor: Colors.white,
+          elevation: 0,
+          title: const Text(
+            'Thông tin cá nhân',
+            style: TextStyle(
+              color: Colors.black87,
+              fontSize: 20,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back, color: Colors.black87),
+            onPressed: () => Navigator.of(context).pop(),
+          ),
+        ),
+        body: const Center(
+          child: Text(
+            'Bạn chưa đăng nhập',
+            style: TextStyle(
+              fontSize: 16,
+              color: Colors.grey,
+            ),
+          ),
+        ),
+      );
+    }
+
+    // Watch profile data
+    final profileAsync = ref.watch(currentUserProfileProvider);
+
+    return Scaffold(
+      backgroundColor: const Color(0xFFF8F9FA),
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        elevation: 0,
+        title: const Text(
+          'Thông tin cá nhân',
+          style: TextStyle(
+            color: Colors.black87,
+            fontSize: 20,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back, color: Colors.black87),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+      ),
+      body: profileAsync.when(
+        data: (profile) {
+          if (profile == null) {
+            return const Center(
+              child: Padding(
+                padding: EdgeInsets.all(24.0),
+                child: Text(
+                  'Chưa có hồ sơ cá nhân',
+                  style: TextStyle(
+                    fontSize: 16,
+                    color: Colors.grey,
+                  ),
+                ),
+              ),
+            );
+          }
+
+          return ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              _buildInfoCard(
+                context,
+                label: 'Họ tên',
+                value: profile.nickname ?? user.displayName ?? '-',
+              ),
+              const SizedBox(height: 8),
+              _buildInfoCard(
+                context,
+                label: 'Email',
+                value: user.email ?? '-',
+              ),
+              const SizedBox(height: 8),
+              _buildInfoCard(
+                context,
+                label: 'Giới tính',
+                value: profile.genderLabel,
+              ),
+              const SizedBox(height: 8),
+              _buildInfoCard(
+                context,
+                label: 'Ngày sinh',
+                value: profile.birthDateString,
+              ),
+              const SizedBox(height: 8),
+              _buildInfoCard(
+                context,
+                label: 'Chiều cao',
+                value: profile.heightCm != null
+                    ? '${profile.heightCm} cm'
+                    : '-',
+              ),
+              const SizedBox(height: 8),
+              _buildInfoCard(
+                context,
+                label: 'Cân nặng hiện tại',
+                value: profile.weightKg != null
+                    ? '${profile.weightKg!.toStringAsFixed(1)} kg'
+                    : '-',
+              ),
+              const SizedBox(height: 8),
+              _buildInfoCard(
+                context,
+                label: 'Mức độ hoạt động',
+                value: profile.activityLevelLabel,
+              ),
+            ],
+          );
+        },
+        loading: () => const Center(
+          child: CircularProgressIndicator(),
+        ),
+        error: (error, stack) => Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24.0),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(
+                  Icons.error_outline,
+                  size: 48,
+                  color: Colors.red[400],
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  'Lỗi tải dữ liệu',
+                  style: TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.red[700],
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  'Đã xảy ra lỗi, vui lòng thử lại sau.\nChi tiết: ${error.toString()}',
+                  style: TextStyle(
+                    fontSize: 14,
+                    color: Colors.grey[600],
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildInfoCard(
+    BuildContext context, {
+    required String label,
+    required String value,
+  }) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.05),
+            blurRadius: 10,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              label,
+              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                    color: Colors.grey[700],
+                  ),
+            ),
+            Text(
+              value,
+              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: Colors.black87,
+                  ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/features/home/presentation/pages/profile_page.dart
+++ b/lib/features/home/presentation/pages/profile_page.dart
@@ -8,6 +8,10 @@ import 'package:calories_app/features/onboarding/domain/profile_model.dart';
 import 'package:calories_app/data/firebase/profile_repository.dart';
 import 'package:calories_app/features/home/presentation/controllers/avatar_upload_controller.dart';
 import 'package:calories_app/features/home/presentation/pages/settings_page.dart';
+import 'package:calories_app/features/home/presentation/pages/reports/nutrition_report_screen.dart';
+import 'package:calories_app/features/home/presentation/pages/reports/workout_report_screen.dart';
+import 'package:calories_app/features/home/presentation/pages/reports/steps_report_screen.dart';
+import 'package:calories_app/features/home/presentation/pages/reports/weight_report_screen.dart';
 import 'package:calories_app/features/home/presentation/widgets/edit_profile_sheet.dart';
 import 'package:calories_app/features/home/presentation/widgets/customize_nutrition_sheet.dart';
 
@@ -643,6 +647,9 @@ class AccountPage extends ConsumerWidget {
     );
   }
 
+  /// Build a report icon button that navigates to the corresponding report screen.
+  /// 
+  /// Navigation pattern: Uses Navigator.push with MaterialPageRoute (consistent with Settings navigation).
   Widget _buildReportIconButton(BuildContext context, {
     required IconData icon,
     required String label,
@@ -650,10 +657,36 @@ class AccountPage extends ConsumerWidget {
   }) {
     return GestureDetector(
       onTap: () {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('Tính năng $label sẽ được cập nhật sau'),
-            duration: const Duration(seconds: 2),
+        // Navigate to the corresponding report screen based on label
+        Widget reportScreen;
+        switch (label) {
+          case 'Dinh dưỡng':
+            reportScreen = const NutritionReportScreen();
+            break;
+          case 'Tập luyện':
+            reportScreen = const WorkoutReportScreen();
+            break;
+          case 'Số bước':
+            reportScreen = const StepsReportScreen();
+            break;
+          case 'Cân nặng':
+            reportScreen = const WeightReportScreen();
+            break;
+          default:
+            // Fallback: show snackbar if label doesn't match
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text('Tính năng $label sẽ được cập nhật sau'),
+                duration: const Duration(seconds: 2),
+              ),
+            );
+            return;
+        }
+
+        // Navigate to the report screen
+        Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (context) => reportScreen,
           ),
         );
       },

--- a/lib/features/home/presentation/pages/reports/nutrition_report_screen.dart
+++ b/lib/features/home/presentation/pages/reports/nutrition_report_screen.dart
@@ -1,0 +1,409 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:calories_app/features/home/presentation/providers/statistics_providers.dart';
+import 'package:calories_app/features/home/domain/statistics_models.dart';
+
+/// Nutrition Report Screen
+/// 
+/// Displays daily/weekly/monthly nutrition statistics including:
+/// - Total calories consumed
+/// - Macro breakdown (protein, carbs, fat)
+/// - Meal patterns and trends
+/// 
+/// Navigation: Accessed from Account page "Xem báo cáo thống kê" > "Dinh dưỡng"
+class NutritionReportScreen extends ConsumerWidget {
+  const NutritionReportScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      backgroundColor: const Color(0xFFF8F9FA),
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        elevation: 0,
+        title: const Text(
+          'Báo cáo dinh dưỡng',
+          style: TextStyle(
+            color: Colors.black87,
+            fontSize: 20,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back, color: Colors.black87),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Description card
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(20),
+              decoration: BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.circular(16),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withValues(alpha: 0.05),
+                    blurRadius: 10,
+                    offset: const Offset(0, 2),
+                  ),
+                ],
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Tổng quan',
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    'Báo cáo này sẽ hiển thị thống kê dinh dưỡng theo ngày, tuần và tháng, bao gồm tổng lượng calo, phân tích đa lượng (protein, carb, fat), và xu hướng bữa ăn.',
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                          color: Colors.grey[600],
+                        ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 24),
+
+            // Today section
+            _buildSection(
+              context,
+              title: 'Hôm nay',
+              child: _buildTodaySection(context, ref),
+            ),
+            const SizedBox(height: 24),
+
+            // This week section
+            _buildSection(
+              context,
+              title: 'Tuần này',
+              child: _buildWeekSection(context, ref),
+            ),
+            const SizedBox(height: 24),
+
+            // This month section
+            _buildSection(
+              context,
+              title: 'Tháng này',
+              child: _buildMonthSection(context, ref),
+            ),
+            const SizedBox(height: 24),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSection(BuildContext context, {required String title, required Widget child}) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                fontWeight: FontWeight.bold,
+                color: Colors.black87,
+              ),
+        ),
+        const SizedBox(height: 16),
+        child,
+      ],
+    );
+  }
+
+  Widget _buildTodaySection(BuildContext context, WidgetRef ref) {
+    final statsAsync = ref.watch(todayNutritionStatsProvider);
+
+    return statsAsync.when(
+      data: (stats) {
+        if (stats.entryCount == 0) {
+          return _buildEmptyState(context, 'Chưa có dữ liệu dinh dưỡng hôm nay');
+        }
+
+        return Column(
+          children: [
+            _buildNutritionSummaryCard(context, stats),
+            const SizedBox(height: 16),
+            _buildMacroBreakdownCard(context, stats),
+          ],
+        );
+      },
+      loading: () => const Center(
+        child: Padding(
+          padding: EdgeInsets.all(40),
+          child: CircularProgressIndicator(),
+        ),
+      ),
+      error: (error, stack) => _buildErrorState(context, error.toString(), () {
+        ref.invalidate(todayNutritionStatsProvider);
+      }),
+    );
+  }
+
+  Widget _buildWeekSection(BuildContext context, WidgetRef ref) {
+    final statsAsync = ref.watch(weekNutritionStatsProvider);
+
+    return statsAsync.when(
+      data: (stats) {
+        if (stats.entryCount == 0) {
+          return _buildEmptyState(context, 'Chưa có dữ liệu dinh dưỡng tuần này');
+        }
+
+        return Column(
+          children: [
+            _buildNutritionSummaryCard(context, stats),
+            const SizedBox(height: 16),
+            _buildMacroBreakdownCard(context, stats),
+            // TODO: Add weekly trends chart here
+          ],
+        );
+      },
+      loading: () => const Center(
+        child: Padding(
+          padding: EdgeInsets.all(40),
+          child: CircularProgressIndicator(),
+        ),
+      ),
+      error: (error, stack) => _buildErrorState(context, error.toString(), () {
+        ref.invalidate(weekNutritionStatsProvider);
+      }),
+    );
+  }
+
+  Widget _buildMonthSection(BuildContext context, WidgetRef ref) {
+    final statsAsync = ref.watch(monthNutritionStatsProvider);
+
+    return statsAsync.when(
+      data: (stats) {
+        if (stats.entryCount == 0) {
+          return _buildEmptyState(context, 'Chưa có dữ liệu dinh dưỡng tháng này');
+        }
+
+        return Column(
+          children: [
+            _buildNutritionSummaryCard(context, stats),
+            const SizedBox(height: 16),
+            _buildMacroBreakdownCard(context, stats),
+            // TODO: Add monthly trends chart here
+          ],
+        );
+      },
+      loading: () => const Center(
+        child: Padding(
+          padding: EdgeInsets.all(40),
+          child: CircularProgressIndicator(),
+        ),
+      ),
+      error: (error, stack) => _buildErrorState(context, error.toString(), () {
+        ref.invalidate(monthNutritionStatsProvider);
+      }),
+    );
+  }
+
+  Widget _buildNutritionSummaryCard(BuildContext context, NutritionStats stats) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.05),
+            blurRadius: 10,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                'Tổng calo',
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+              ),
+              if (stats.targetCalories != null)
+                Text(
+                  'Mục tiêu: ${stats.targetCalories!.toStringAsFixed(0)} kcal',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: Colors.grey[600],
+                      ),
+                ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Text(
+            stats.totalCalories.toStringAsFixed(0),
+            style: Theme.of(context).textTheme.displayMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  color: Colors.black87,
+                ),
+          ),
+          Text(
+            'kcal',
+            style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                  color: Colors.grey[600],
+                ),
+          ),
+          if (stats.targetCalories != null) ...[
+            const SizedBox(height: 12),
+            LinearProgressIndicator(
+              value: stats.progress.clamp(0, 1),
+              backgroundColor: Colors.grey[200],
+              valueColor: AlwaysStoppedAnimation<Color>(
+                stats.isTargetMet ? Colors.green : Colors.blue,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              stats.isTargetMet
+                  ? 'Đã đạt mục tiêu! (Dư ${stats.exceeded.toStringAsFixed(0)} kcal)'
+                  : 'Còn ${stats.remaining.toStringAsFixed(0)} kcal để đạt mục tiêu',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: stats.isTargetMet ? Colors.green : Colors.grey[600],
+                  ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMacroBreakdownCard(BuildContext context, NutritionStats stats) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.05),
+            blurRadius: 10,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Phân tích đa lượng',
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+          ),
+          const SizedBox(height: 16),
+          _buildMacroRow(context, 'Chất đạm', stats.totalProtein, const Color(0xFF81C784)),
+          const SizedBox(height: 12),
+          _buildMacroRow(context, 'Đường bột', stats.totalCarbs, const Color(0xFF64B5F6)),
+          const SizedBox(height: 12),
+          _buildMacroRow(context, 'Chất béo', stats.totalFat, const Color(0xFFF48FB1)),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMacroRow(BuildContext context, String label, double grams, Color color) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(
+          label,
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
+        Text(
+          '${grams.toStringAsFixed(1)} g',
+          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+                color: color,
+              ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildEmptyState(BuildContext context, String message) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(40),
+      decoration: BoxDecoration(
+        color: Colors.grey[100],
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        children: [
+          Icon(
+            Icons.restaurant_menu,
+            size: 48,
+            color: Colors.grey[400],
+          ),
+          const SizedBox(height: 12),
+          Text(
+            message,
+            style: TextStyle(
+              color: Colors.grey[600],
+              fontSize: 14,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildErrorState(BuildContext context, String error, VoidCallback onRetry) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: Colors.red[50],
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: Colors.red[200]!),
+      ),
+      child: Column(
+        children: [
+          Icon(Icons.error_outline, color: Colors.red[400], size: 32),
+          const SizedBox(height: 8),
+          Text(
+            'Lỗi tải dữ liệu',
+            style: TextStyle(
+              color: Colors.red[700],
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            error,
+            style: TextStyle(
+              color: Colors.red[600],
+              fontSize: 12,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 12),
+          TextButton(
+            onPressed: onRetry,
+            child: const Text('Thử lại'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/lib/features/home/presentation/pages/reports/steps_report_screen.dart
+++ b/lib/features/home/presentation/pages/reports/steps_report_screen.dart
@@ -1,0 +1,217 @@
+import 'package:flutter/material.dart';
+
+/// Steps Report Screen
+/// 
+/// Displays daily/weekly/monthly step statistics including:
+/// - Total steps taken
+/// - Daily step goals and achievements
+/// - Step trends and patterns
+/// 
+/// Navigation: Accessed from Account page "Xem báo cáo thống kê" > "Số bước"
+class StepsReportScreen extends StatelessWidget {
+  const StepsReportScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFFF8F9FA),
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        elevation: 0,
+        title: const Text(
+          'Báo cáo số bước',
+          style: TextStyle(
+            color: Colors.black87,
+            fontSize: 20,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back, color: Colors.black87),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Description card
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(20),
+              decoration: BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.circular(16),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withValues(alpha: 0.05),
+                    blurRadius: 10,
+                    offset: const Offset(0, 2),
+                  ),
+                ],
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Tổng quan',
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    'Báo cáo này sẽ hiển thị thống kê số bước theo ngày, tuần và tháng, bao gồm tổng số bước đi, mục tiêu hàng ngày, và xu hướng hoạt động.',
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                          color: Colors.grey[600],
+                        ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 24),
+
+            // Today section
+            _buildSection(
+              context,
+              title: 'Hôm nay',
+              child: Column(
+                children: [
+                  // TODO: Add today's steps summary card (total steps, goal progress)
+                  // TODO: Add today's step chart (hourly breakdown)
+                  // TODO: Add today's activity timeline
+                  Container(
+                    width: double.infinity,
+                    padding: const EdgeInsets.all(40),
+                    decoration: BoxDecoration(
+                      color: Colors.grey[100],
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: Column(
+                      children: [
+                        Icon(
+                          Icons.directions_walk,
+                          size: 48,
+                          color: Colors.grey[400],
+                        ),
+                        const SizedBox(height: 12),
+                        Text(
+                          'Dữ liệu số bước hôm nay sẽ được hiển thị tại đây',
+                          style: TextStyle(
+                            color: Colors.grey[600],
+                            fontSize: 14,
+                          ),
+                          textAlign: TextAlign.center,
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 24),
+
+            // This week section
+            _buildSection(
+              context,
+              title: 'Tuần này',
+              child: Column(
+                children: [
+                  // TODO: Add weekly steps trends chart
+                  // TODO: Add weekly average steps
+                  // TODO: Add weekly step goal achievements
+                  Container(
+                    width: double.infinity,
+                    padding: const EdgeInsets.all(40),
+                    decoration: BoxDecoration(
+                      color: Colors.grey[100],
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: Column(
+                      children: [
+                        Icon(
+                          Icons.show_chart,
+                          size: 48,
+                          color: Colors.grey[400],
+                        ),
+                        const SizedBox(height: 12),
+                        Text(
+                          'Biểu đồ xu hướng số bước tuần này sẽ được hiển thị tại đây',
+                          style: TextStyle(
+                            color: Colors.grey[600],
+                            fontSize: 14,
+                          ),
+                          textAlign: TextAlign.center,
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 24),
+
+            // This month section
+            _buildSection(
+              context,
+              title: 'Tháng này',
+              child: Column(
+                children: [
+                  // TODO: Add monthly steps summary
+                  // TODO: Add monthly trends and patterns
+                  // TODO: Add monthly goals vs actual comparison
+                  Container(
+                    width: double.infinity,
+                    padding: const EdgeInsets.all(40),
+                    decoration: BoxDecoration(
+                      color: Colors.grey[100],
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: Column(
+                      children: [
+                        Icon(
+                          Icons.calendar_month,
+                          size: 48,
+                          color: Colors.grey[400],
+                        ),
+                        const SizedBox(height: 12),
+                        Text(
+                          'Thống kê số bước tháng này sẽ được hiển thị tại đây',
+                          style: TextStyle(
+                            color: Colors.grey[600],
+                            fontSize: 14,
+                          ),
+                          textAlign: TextAlign.center,
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 24),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSection(BuildContext context, {required String title, required Widget child}) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                fontWeight: FontWeight.bold,
+                color: Colors.black87,
+              ),
+        ),
+        const SizedBox(height: 16),
+        child,
+      ],
+    );
+  }
+}
+

--- a/lib/features/home/presentation/pages/reports/weight_report_screen.dart
+++ b/lib/features/home/presentation/pages/reports/weight_report_screen.dart
@@ -1,0 +1,425 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:calories_app/features/home/presentation/providers/statistics_providers.dart';
+import 'package:calories_app/features/home/domain/statistics_models.dart';
+
+/// Weight Report Screen
+/// 
+/// Displays daily/weekly/monthly weight statistics including:
+/// - Weight trends and progress
+/// - Weight change over time
+/// - Goal progress visualization
+/// 
+/// Navigation: Accessed from Account page "Xem báo cáo thống kê" > "Cân nặng"
+class WeightReportScreen extends ConsumerWidget {
+  const WeightReportScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      backgroundColor: const Color(0xFFF8F9FA),
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        elevation: 0,
+        title: const Text(
+          'Báo cáo cân nặng',
+          style: TextStyle(
+            color: Colors.black87,
+            fontSize: 20,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back, color: Colors.black87),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Description card
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(20),
+              decoration: BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.circular(16),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withValues(alpha: 0.05),
+                    blurRadius: 10,
+                    offset: const Offset(0, 2),
+                  ),
+                ],
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Tổng quan',
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    'Báo cáo này sẽ hiển thị thống kê cân nặng theo ngày, tuần và tháng, bao gồm xu hướng cân nặng, tiến độ mục tiêu, và biểu đồ thay đổi theo thời gian.',
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                          color: Colors.grey[600],
+                        ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 24),
+
+            // Today section
+            _buildSection(
+              context,
+              title: 'Hôm nay',
+              child: _buildTodaySection(context, ref),
+            ),
+            const SizedBox(height: 24),
+
+            // This week section
+            _buildSection(
+              context,
+              title: 'Tuần này',
+              child: _buildWeekSection(context, ref),
+            ),
+            const SizedBox(height: 24),
+
+            // This month section
+            _buildSection(
+              context,
+              title: 'Tháng này',
+              child: _buildMonthSection(context, ref),
+            ),
+            const SizedBox(height: 24),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSection(BuildContext context, {required String title, required Widget child}) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                fontWeight: FontWeight.bold,
+                color: Colors.black87,
+              ),
+        ),
+        const SizedBox(height: 16),
+        child,
+      ],
+    );
+  }
+
+  Widget _buildTodaySection(BuildContext context, WidgetRef ref) {
+    final statsAsync = ref.watch(todayWeightStatsProvider);
+
+    return statsAsync.when(
+      data: (stats) {
+        if (stats.latestWeight == null) {
+          return _buildEmptyState(context, 'Chưa có dữ liệu cân nặng hôm nay');
+        }
+        return _buildWeightSummaryCard(context, stats, isToday: true);
+      },
+      loading: () => const Center(
+        child: Padding(
+          padding: EdgeInsets.all(40),
+          child: CircularProgressIndicator(),
+        ),
+      ),
+      error: (error, stack) => _buildErrorState(context, error.toString(), () {
+        ref.invalidate(todayWeightStatsProvider);
+      }),
+    );
+  }
+
+  Widget _buildWeekSection(BuildContext context, WidgetRef ref) {
+    final statsAsync = ref.watch(weekWeightStatsProvider);
+
+    return statsAsync.when(
+      data: (stats) {
+        if (stats.entryCount == 0) {
+          return _buildEmptyState(context, 'Chưa có dữ liệu cân nặng tuần này');
+        }
+        return _buildWeightSummaryCard(context, stats, isToday: false);
+      },
+      loading: () => const Center(
+        child: Padding(
+          padding: EdgeInsets.all(40),
+          child: CircularProgressIndicator(),
+        ),
+      ),
+      error: (error, stack) => _buildErrorState(context, error.toString(), () {
+        ref.invalidate(weekWeightStatsProvider);
+      }),
+    );
+  }
+
+  Widget _buildMonthSection(BuildContext context, WidgetRef ref) {
+    final statsAsync = ref.watch(monthWeightStatsProvider);
+
+    return statsAsync.when(
+      data: (stats) {
+        if (stats.entryCount == 0) {
+          return _buildEmptyState(context, 'Chưa có dữ liệu cân nặng tháng này');
+        }
+        return _buildWeightSummaryCard(context, stats, isToday: false);
+      },
+      loading: () => const Center(
+        child: Padding(
+          padding: EdgeInsets.all(40),
+          child: CircularProgressIndicator(),
+        ),
+      ),
+      error: (error, stack) => _buildErrorState(context, error.toString(), () {
+        ref.invalidate(monthWeightStatsProvider);
+      }),
+    );
+  }
+
+  Widget _buildWeightSummaryCard(BuildContext context, WeightStats stats, {required bool isToday}) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.05),
+            blurRadius: 10,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Current weight
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                'Cân nặng hiện tại',
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+              ),
+              if (stats.targetWeight != null)
+                Text(
+                  'Mục tiêu: ${stats.targetWeight!.toStringAsFixed(1)} kg',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: Colors.grey[600],
+                      ),
+                ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Text(
+            stats.latestWeight!.toStringAsFixed(1),
+            style: Theme.of(context).textTheme.displayMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  color: Colors.black87,
+                ),
+          ),
+          Text(
+            'kg',
+            style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                  color: Colors.grey[600],
+                ),
+          ),
+          
+          // Change indicator
+          if (isToday && stats.changeVsPrevious != null) ...[
+            const SizedBox(height: 16),
+            _buildChangeRow(
+              context,
+              stats.changeVsPrevious! > 0
+                  ? '+${stats.changeVsPrevious!.toStringAsFixed(1)} kg so với hôm qua'
+                  : '${stats.changeVsPrevious!.toStringAsFixed(1)} kg so với hôm qua',
+              stats.changeVsPrevious! > 0 ? Colors.red : Colors.green,
+            ),
+          ] else if (!isToday && stats.weightChange != null) ...[
+            const SizedBox(height: 16),
+            _buildChangeRow(
+              context,
+              stats.weightChange! > 0
+                  ? '+${stats.weightChange!.toStringAsFixed(1)} kg'
+                  : '${stats.weightChange!.toStringAsFixed(1)} kg',
+              stats.isWeightGain ? Colors.red : Colors.green,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              stats.trendLabel,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Colors.grey[600],
+                  ),
+            ),
+          ],
+          
+          // Progress to goal
+          if (stats.targetWeight != null && stats.progressToGoal != null) ...[
+            const SizedBox(height: 16),
+            LinearProgressIndicator(
+              value: stats.progressToGoal!.clamp(0, 1),
+              backgroundColor: Colors.grey[200],
+              valueColor: AlwaysStoppedAnimation<Color>(Colors.blue),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Tiến độ: ${(stats.progressToGoal! * 100).toStringAsFixed(0)}%',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Colors.grey[600],
+                  ),
+            ),
+          ],
+          
+          // Start and end weights for week/month
+          if (!isToday && stats.earliestWeight != null) ...[
+            const SizedBox(height: 16),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Cân nặng đầu kỳ',
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: Colors.grey[600],
+                          ),
+                    ),
+                    Text(
+                      '${stats.earliestWeight!.toStringAsFixed(1)} kg',
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                            fontWeight: FontWeight.bold,
+                          ),
+                    ),
+                  ],
+                ),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    Text(
+                      'Cân nặng cuối kỳ',
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: Colors.grey[600],
+                          ),
+                    ),
+                    Text(
+                      '${stats.latestWeight!.toStringAsFixed(1)} kg',
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                            fontWeight: FontWeight.bold,
+                          ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ],
+          
+          // TODO: Add simple weight trend chart here using weightHistory
+        ],
+      ),
+    );
+  }
+
+  Widget _buildChangeRow(BuildContext context, String text, Color color) {
+    return Row(
+      children: [
+        Icon(
+          color == Colors.green ? Icons.trending_down : Icons.trending_up,
+          color: color,
+          size: 20,
+        ),
+        const SizedBox(width: 8),
+        Text(
+          text,
+          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: color,
+                fontWeight: FontWeight.w600,
+              ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildEmptyState(BuildContext context, String message) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(40),
+      decoration: BoxDecoration(
+        color: Colors.grey[100],
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        children: [
+          Icon(
+            Icons.monitor_weight,
+            size: 48,
+            color: Colors.grey[400],
+          ),
+          const SizedBox(height: 12),
+          Text(
+            message,
+            style: TextStyle(
+              color: Colors.grey[600],
+              fontSize: 14,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildErrorState(BuildContext context, String error, VoidCallback onRetry) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: Colors.red[50],
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: Colors.red[200]!),
+      ),
+      child: Column(
+        children: [
+          Icon(Icons.error_outline, color: Colors.red[400], size: 32),
+          const SizedBox(height: 8),
+          Text(
+            'Lỗi tải dữ liệu',
+            style: TextStyle(
+              color: Colors.red[700],
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            error,
+            style: TextStyle(
+              color: Colors.red[600],
+              fontSize: 12,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 12),
+          TextButton(
+            onPressed: onRetry,
+            child: const Text('Thử lại'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/lib/features/home/presentation/pages/reports/workout_report_screen.dart
+++ b/lib/features/home/presentation/pages/reports/workout_report_screen.dart
@@ -1,0 +1,370 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:calories_app/features/home/presentation/providers/statistics_providers.dart';
+import 'package:calories_app/features/home/domain/statistics_models.dart';
+
+/// Workout Report Screen
+/// 
+/// Displays daily/weekly/monthly workout statistics including:
+/// - Total calories burned
+/// - Exercise duration and frequency
+/// - Workout types and trends
+/// 
+/// Navigation: Accessed from Account page "Xem báo cáo thống kê" > "Tập luyện"
+class WorkoutReportScreen extends ConsumerWidget {
+  const WorkoutReportScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      backgroundColor: const Color(0xFFF8F9FA),
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        elevation: 0,
+        title: const Text(
+          'Báo cáo tập luyện',
+          style: TextStyle(
+            color: Colors.black87,
+            fontSize: 20,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back, color: Colors.black87),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Description card
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(20),
+              decoration: BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.circular(16),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withValues(alpha: 0.05),
+                    blurRadius: 10,
+                    offset: const Offset(0, 2),
+                  ),
+                ],
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Tổng quan',
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    'Báo cáo này sẽ hiển thị thống kê tập luyện theo ngày, tuần và tháng, bao gồm tổng lượng calo đốt cháy, thời gian tập luyện, tần suất, và xu hướng các loại bài tập.',
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                          color: Colors.grey[600],
+                        ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 24),
+
+            // Today section
+            _buildSection(
+              context,
+              title: 'Hôm nay',
+              child: _buildTodaySection(context, ref),
+            ),
+            const SizedBox(height: 24),
+
+            // This week section
+            _buildSection(
+              context,
+              title: 'Tuần này',
+              child: _buildWeekSection(context, ref),
+            ),
+            const SizedBox(height: 24),
+
+            // This month section
+            _buildSection(
+              context,
+              title: 'Tháng này',
+              child: _buildMonthSection(context, ref),
+            ),
+            const SizedBox(height: 24),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSection(BuildContext context, {required String title, required Widget child}) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                fontWeight: FontWeight.bold,
+                color: Colors.black87,
+              ),
+        ),
+        const SizedBox(height: 16),
+        child,
+      ],
+    );
+  }
+
+  Widget _buildTodaySection(BuildContext context, WidgetRef ref) {
+    final statsAsync = ref.watch(todayWorkoutStatsProvider);
+
+    return statsAsync.when(
+      data: (stats) {
+        if (stats.workoutCount == 0) {
+          return _buildEmptyState(context, 'Chưa có dữ liệu tập luyện hôm nay');
+        }
+        return _buildWorkoutSummaryCard(context, stats);
+      },
+      loading: () => const Center(
+        child: Padding(
+          padding: EdgeInsets.all(40),
+          child: CircularProgressIndicator(),
+        ),
+      ),
+      error: (error, stack) => _buildErrorState(context, error.toString(), () {
+        ref.invalidate(todayWorkoutStatsProvider);
+      }),
+    );
+  }
+
+  Widget _buildWeekSection(BuildContext context, WidgetRef ref) {
+    final statsAsync = ref.watch(weekWorkoutStatsProvider);
+
+    return statsAsync.when(
+      data: (stats) {
+        if (stats.workoutCount == 0) {
+          return _buildEmptyState(context, 'Chưa có dữ liệu tập luyện tuần này');
+        }
+        return _buildWorkoutSummaryCard(context, stats);
+      },
+      loading: () => const Center(
+        child: Padding(
+          padding: EdgeInsets.all(40),
+          child: CircularProgressIndicator(),
+        ),
+      ),
+      error: (error, stack) => _buildErrorState(context, error.toString(), () {
+        ref.invalidate(weekWorkoutStatsProvider);
+      }),
+    );
+  }
+
+  Widget _buildMonthSection(BuildContext context, WidgetRef ref) {
+    final statsAsync = ref.watch(monthWorkoutStatsProvider);
+
+    return statsAsync.when(
+      data: (stats) {
+        if (stats.workoutCount == 0) {
+          return _buildEmptyState(context, 'Chưa có dữ liệu tập luyện tháng này');
+        }
+        return _buildWorkoutSummaryCard(context, stats);
+      },
+      loading: () => const Center(
+        child: Padding(
+          padding: EdgeInsets.all(40),
+          child: CircularProgressIndicator(),
+        ),
+      ),
+      error: (error, stack) => _buildErrorState(context, error.toString(), () {
+        ref.invalidate(monthWorkoutStatsProvider);
+      }),
+    );
+  }
+
+  Widget _buildWorkoutSummaryCard(BuildContext context, WorkoutStats stats) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.05),
+            blurRadius: 10,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Tổng quan',
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+          ),
+          const SizedBox(height: 16),
+          _buildStatRow(
+            context,
+            'Calo đốt cháy',
+            '${stats.totalCaloriesBurned.toStringAsFixed(0)} kcal',
+            Icons.local_fire_department,
+            Colors.orange,
+          ),
+          const SizedBox(height: 12),
+          _buildStatRow(
+            context,
+            'Thời gian tập luyện',
+            '${stats.totalDurationMinutes.toStringAsFixed(0)} phút',
+            Icons.timer,
+            Colors.blue,
+          ),
+          const SizedBox(height: 12),
+          _buildStatRow(
+            context,
+            'Số buổi tập',
+            '${stats.workoutCount} buổi',
+            Icons.fitness_center,
+            Colors.green,
+          ),
+          if (stats.workoutCount > 0) ...[
+            const SizedBox(height: 12),
+            _buildStatRow(
+              context,
+              'Trung bình calo/buổi',
+              '${stats.avgCaloriesPerWorkout.toStringAsFixed(0)} kcal',
+              Icons.trending_up,
+              Colors.purple,
+            ),
+          ],
+          if (stats.exerciseNames.isNotEmpty) ...[
+            const SizedBox(height: 16),
+            Text(
+              'Các bài tập',
+              style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+            ),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: stats.exerciseNames.map((name) {
+                return Chip(
+                  label: Text(name),
+                  backgroundColor: Colors.green[50],
+                  labelStyle: const TextStyle(fontSize: 12),
+                );
+              }).toList(),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildStatRow(
+    BuildContext context,
+    String label,
+    String value,
+    IconData icon,
+    Color color,
+  ) {
+    return Row(
+      children: [
+        Icon(icon, color: color, size: 20),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Text(
+            label,
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+        ),
+        Text(
+          value,
+          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+                color: color,
+              ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildEmptyState(BuildContext context, String message) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(40),
+      decoration: BoxDecoration(
+        color: Colors.grey[100],
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        children: [
+          Icon(
+            Icons.fitness_center,
+            size: 48,
+            color: Colors.grey[400],
+          ),
+          const SizedBox(height: 12),
+          Text(
+            message,
+            style: TextStyle(
+              color: Colors.grey[600],
+              fontSize: 14,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildErrorState(BuildContext context, String error, VoidCallback onRetry) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: Colors.red[50],
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: Colors.red[200]!),
+      ),
+      child: Column(
+        children: [
+          Icon(Icons.error_outline, color: Colors.red[400], size: 32),
+          const SizedBox(height: 8),
+          Text(
+            'Lỗi tải dữ liệu',
+            style: TextStyle(
+              color: Colors.red[700],
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            error,
+            style: TextStyle(
+              color: Colors.red[600],
+              fontSize: 12,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 12),
+          TextButton(
+            onPressed: onRetry,
+            child: const Text('Thử lại'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/lib/features/home/presentation/pages/settings_page.dart
+++ b/lib/features/home/presentation/pages/settings_page.dart
@@ -8,6 +8,8 @@ import 'package:calories_app/features/onboarding/presentation/controllers/onboar
 import 'package:calories_app/features/foods/ui/food_admin_page.dart';
 import 'package:calories_app/features/exercise/ui/exercise_admin_list_screen.dart';
 import 'package:calories_app/features/admin/ui/admin_dashboard_screen.dart';
+import 'package:calories_app/features/home/presentation/pages/personal_info_screen.dart';
+import 'package:calories_app/features/home/presentation/pages/goals_screen.dart';
 
 /// Settings page with clean WAO-style design
 class SettingsPage extends ConsumerWidget {
@@ -299,69 +301,9 @@ class SettingsPage extends ConsumerWidget {
   }
 
   void _navigateToPersonalInfo(BuildContext context, WidgetRef ref) {
-    final user = FirebaseAuth.instance.currentUser;
-    final profileDataAsync = user != null
-        ? ref.read(currentUserProfileDataProvider(user.uid))
-        : null;
-
     Navigator.of(context).push(
       MaterialPageRoute(
-        builder: (context) => Scaffold(
-          appBar: AppBar(title: const Text('Thông tin cá nhân')),
-          body: profileDataAsync == null
-              ? const Center(child: CircularProgressIndicator())
-              : profileDataAsync.when(
-                  data: (profile) {
-                    if (profile == null) {
-                      return const Center(child: Text('Không có thông tin'));
-                    }
-                    return ListView(
-                      padding: const EdgeInsets.all(16),
-                      children: [
-                        _buildInfoTile('Tên', profile.nickname ?? '-'),
-                        _buildInfoTile('Email', user?.email ?? '-'),
-                        _buildInfoTile('Tuổi', profile.age?.toString() ?? '-'),
-                        _buildInfoTile('Giới tính', profile.gender ?? '-'),
-                        _buildInfoTile(
-                          'Cân nặng',
-                          profile.weightKg != null
-                              ? '${profile.weightKg!.toStringAsFixed(1)} kg'
-                              : '-',
-                        ),
-                        _buildInfoTile(
-                          'Chiều cao',
-                          profile.heightCm != null
-                              ? '${profile.heightCm} cm'
-                              : '-',
-                        ),
-                        _buildInfoTile(
-                          'BMI',
-                          profile.bmi != null
-                              ? profile.bmi!.toStringAsFixed(1)
-                              : '-',
-                        ),
-                        _buildInfoTile(
-                          'Mức độ hoạt động',
-                          profile.activityLevel ?? '-',
-                        ),
-                      ],
-                    );
-                  },
-                  loading: () =>
-                      const Center(child: CircularProgressIndicator()),
-                  error: (error, _) => Center(child: Text('Lỗi: $error')),
-                ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildInfoTile(String label, String value) {
-    return Card(
-      margin: const EdgeInsets.only(bottom: 8),
-      child: ListTile(
-        title: Text(label, style: const TextStyle(fontWeight: FontWeight.bold)),
-        subtitle: Text(value),
+        builder: (context) => const PersonalInfoScreen(),
       ),
     );
   }
@@ -369,34 +311,7 @@ class SettingsPage extends ConsumerWidget {
   void _navigateToGoals(BuildContext context, WidgetRef ref) {
     Navigator.of(context).push(
       MaterialPageRoute(
-        builder: (context) => Scaffold(
-          appBar: AppBar(title: const Text('Mục tiêu của tôi')),
-          body: const Center(
-            child: Padding(
-              padding: EdgeInsets.all(24.0),
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Icon(
-                    Icons.track_changes_outlined,
-                    size: 64,
-                    color: Colors.grey,
-                  ),
-                  SizedBox(height: 16),
-                  Text(
-                    'Mục tiêu của tôi',
-                    style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
-                  ),
-                  SizedBox(height: 8),
-                  Text(
-                    'Tính năng này đang được phát triển.',
-                    style: TextStyle(color: Colors.grey),
-                  ),
-                ],
-              ),
-            ),
-          ),
-        ),
+        builder: (context) => const GoalsScreen(),
       ),
     );
   }

--- a/lib/features/home/presentation/providers/statistics_providers.dart
+++ b/lib/features/home/presentation/providers/statistics_providers.dart
@@ -1,0 +1,624 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:calories_app/data/firebase/diary_repository.dart';
+import 'package:calories_app/data/firebase/weight_repository.dart';
+import 'package:calories_app/core/health/health_providers.dart';
+import 'package:calories_app/features/home/domain/diary_entry.dart';
+import 'package:calories_app/features/home/domain/statistics_models.dart';
+import 'package:calories_app/shared/state/auth_providers.dart';
+import 'package:calories_app/data/firebase/date_utils.dart';
+
+/// Provider for DiaryRepository
+final diaryRepositoryProvider = Provider<DiaryRepository>((ref) {
+  return DiaryRepository();
+});
+
+/// Provider for WeightRepository
+final weightRepositoryProvider = Provider<WeightRepository>((ref) {
+  return WeightRepository();
+});
+
+/// Helper provider to get the current user's UID
+final currentUserIdProvider = Provider<String?>((ref) {
+  return ref.watch(authStateProvider).whenOrNull(
+        data: (user) => user?.uid,
+      );
+});
+
+// ============================================================================
+// NUTRITION STATISTICS PROVIDERS
+// ============================================================================
+
+/// Get nutrition statistics for today
+final todayNutritionStatsProvider = FutureProvider<NutritionStats>((ref) async {
+  final uid = ref.watch(currentUserIdProvider);
+  if (uid == null) {
+    throw Exception('User not logged in');
+  }
+
+  try {
+    final now = DateTime.now();
+    final today = DateUtils.normalizeToMidnight(now);
+    
+    final repository = ref.read(diaryRepositoryProvider);
+    final entries = await repository.getDiaryEntriesForDateRange(
+      uid: uid,
+      startDate: today,
+      endDate: today, // Use same date for single-day query
+    );
+
+    // Filter food entries only
+    final foodEntries = entries.where((e) => e.type == DiaryEntryType.food).toList();
+
+    // Aggregate nutrition data
+    double totalCalories = 0.0;
+    double totalProtein = 0.0;
+    double totalCarbs = 0.0;
+    double totalFat = 0.0;
+
+    for (final entry in foodEntries) {
+      totalCalories += entry.calories;
+      totalProtein += entry.protein ?? 0.0;
+      totalCarbs += entry.carbs ?? 0.0;
+      totalFat += entry.fat ?? 0.0;
+    }
+
+    // Get target calories from profile
+    final profileAsync = ref.read(currentUserProfileProvider);
+    final targetCalories = profileAsync.maybeWhen(
+      data: (profile) => profile?.targetKcal,
+      orElse: () => null,
+    );
+
+    return NutritionStats(
+      totalCalories: totalCalories,
+      totalProtein: totalProtein,
+      totalCarbs: totalCarbs,
+      totalFat: totalFat,
+      entryCount: foodEntries.length,
+      targetCalories: targetCalories,
+    );
+  } catch (e) {
+    // Re-throw with a more user-friendly message
+    throw Exception('Không thể tải dữ liệu dinh dưỡng hôm nay: ${e.toString()}');
+  }
+});
+
+/// Get nutrition statistics for this week (last 7 days)
+final weekNutritionStatsProvider = FutureProvider<NutritionStats>((ref) async {
+  final uid = ref.watch(currentUserIdProvider);
+  if (uid == null) {
+    throw Exception('User not logged in');
+  }
+
+  final now = DateTime.now();
+  final startDate = now.subtract(const Duration(days: 6)); // Last 7 days including today
+  final normalizedStart = DateUtils.normalizeToMidnight(startDate);
+  
+  final repository = ref.read(diaryRepositoryProvider);
+  final entries = await repository.getDiaryEntriesForDateRange(
+    uid: uid,
+    startDate: normalizedStart,
+    endDate: now,
+  );
+
+  // Filter food entries only
+  final foodEntries = entries.where((e) => e.type == DiaryEntryType.food).toList();
+
+  // Aggregate nutrition data
+  double totalCalories = 0.0;
+  double totalProtein = 0.0;
+  double totalCarbs = 0.0;
+  double totalFat = 0.0;
+
+  for (final entry in foodEntries) {
+    totalCalories += entry.calories;
+    totalProtein += entry.protein ?? 0.0;
+    totalCarbs += entry.carbs ?? 0.0;
+    totalFat += entry.fat ?? 0.0;
+  }
+
+  // Get target calories from profile (multiply by 7 for weekly target)
+  final profileAsync = ref.read(currentUserProfileProvider);
+  final dailyTarget = profileAsync.maybeWhen(
+    data: (profile) => profile?.targetKcal,
+    orElse: () => null,
+  );
+  final targetCalories = dailyTarget != null ? dailyTarget * 7 : null;
+
+  return NutritionStats(
+    totalCalories: totalCalories,
+    totalProtein: totalProtein,
+    totalCarbs: totalCarbs,
+    totalFat: totalFat,
+    entryCount: foodEntries.length,
+    targetCalories: targetCalories,
+  );
+});
+
+/// Get nutrition statistics for this month
+final monthNutritionStatsProvider = FutureProvider<NutritionStats>((ref) async {
+  final uid = ref.watch(currentUserIdProvider);
+  if (uid == null) {
+    throw Exception('User not logged in');
+  }
+
+  final now = DateTime.now();
+  final startDate = DateTime(now.year, now.month, 1); // First day of month
+  final normalizedStart = DateUtils.normalizeToMidnight(startDate);
+  
+  final repository = ref.read(diaryRepositoryProvider);
+  final entries = await repository.getDiaryEntriesForDateRange(
+    uid: uid,
+    startDate: normalizedStart,
+    endDate: now,
+  );
+
+  // Filter food entries only
+  final foodEntries = entries.where((e) => e.type == DiaryEntryType.food).toList();
+
+  // Aggregate nutrition data
+  double totalCalories = 0.0;
+  double totalProtein = 0.0;
+  double totalCarbs = 0.0;
+  double totalFat = 0.0;
+
+  for (final entry in foodEntries) {
+    totalCalories += entry.calories;
+    totalProtein += entry.protein ?? 0.0;
+    totalCarbs += entry.carbs ?? 0.0;
+    totalFat += entry.fat ?? 0.0;
+  }
+
+  // Get target calories from profile (multiply by days in month)
+  final profileAsync = ref.read(currentUserProfileProvider);
+  final dailyTarget = profileAsync.maybeWhen(
+    data: (profile) => profile?.targetKcal,
+    orElse: () => null,
+  );
+  final daysInMonth = DateTime(now.year, now.month + 1, 0).day;
+  final targetCalories = dailyTarget != null ? dailyTarget * daysInMonth : null;
+
+  return NutritionStats(
+    totalCalories: totalCalories,
+    totalProtein: totalProtein,
+    totalCarbs: totalCarbs,
+    totalFat: totalFat,
+    entryCount: foodEntries.length,
+    targetCalories: targetCalories,
+  );
+});
+
+// ============================================================================
+// WORKOUT STATISTICS PROVIDERS
+// ============================================================================
+
+/// Get workout statistics for today
+final todayWorkoutStatsProvider = FutureProvider<WorkoutStats>((ref) async {
+  final uid = ref.watch(currentUserIdProvider);
+  if (uid == null) {
+    throw Exception('User not logged in');
+  }
+
+  try {
+    final now = DateTime.now();
+    final today = DateUtils.normalizeToMidnight(now);
+    
+    final repository = ref.read(diaryRepositoryProvider);
+    final entries = await repository.getDiaryEntriesForDateRange(
+      uid: uid,
+      startDate: today,
+      endDate: today, // Use same date for single-day query
+    );
+
+    // Filter exercise entries only
+    final exerciseEntries = entries.where((e) => e.type == DiaryEntryType.exercise).toList();
+
+    // Aggregate workout data
+    double totalCaloriesBurned = 0.0;
+    double totalDurationMinutes = 0.0;
+    final exerciseNames = <String>{};
+
+    for (final entry in exerciseEntries) {
+      totalCaloriesBurned += entry.calories;
+      totalDurationMinutes += entry.durationMinutes ?? 0.0;
+      if (entry.exerciseName != null) {
+        exerciseNames.add(entry.exerciseName!);
+      }
+    }
+
+    return WorkoutStats(
+      totalCaloriesBurned: totalCaloriesBurned,
+      totalDurationMinutes: totalDurationMinutes,
+      workoutCount: exerciseEntries.length,
+      exerciseNames: exerciseNames.toList()..sort(),
+    );
+  } catch (e) {
+    // Re-throw with a more user-friendly message
+    throw Exception('Không thể tải dữ liệu tập luyện hôm nay: ${e.toString()}');
+  }
+});
+
+/// Get workout statistics for this week (last 7 days)
+final weekWorkoutStatsProvider = FutureProvider<WorkoutStats>((ref) async {
+  final uid = ref.watch(currentUserIdProvider);
+  if (uid == null) {
+    throw Exception('User not logged in');
+  }
+
+  final now = DateTime.now();
+  final startDate = now.subtract(const Duration(days: 6));
+  final normalizedStart = DateUtils.normalizeToMidnight(startDate);
+  
+  final repository = ref.read(diaryRepositoryProvider);
+  final entries = await repository.getDiaryEntriesForDateRange(
+    uid: uid,
+    startDate: normalizedStart,
+    endDate: now,
+  );
+
+  // Filter exercise entries only
+  final exerciseEntries = entries.where((e) => e.type == DiaryEntryType.exercise).toList();
+
+  // Aggregate workout data
+  double totalCaloriesBurned = 0.0;
+  double totalDurationMinutes = 0.0;
+  final exerciseNames = <String>{};
+
+  for (final entry in exerciseEntries) {
+    totalCaloriesBurned += entry.calories;
+    totalDurationMinutes += entry.durationMinutes ?? 0.0;
+    if (entry.exerciseName != null) {
+      exerciseNames.add(entry.exerciseName!);
+    }
+  }
+
+  return WorkoutStats(
+    totalCaloriesBurned: totalCaloriesBurned,
+    totalDurationMinutes: totalDurationMinutes,
+    workoutCount: exerciseEntries.length,
+    exerciseNames: exerciseNames.toList()..sort(),
+  );
+});
+
+/// Get workout statistics for this month
+final monthWorkoutStatsProvider = FutureProvider<WorkoutStats>((ref) async {
+  final uid = ref.watch(currentUserIdProvider);
+  if (uid == null) {
+    throw Exception('User not logged in');
+  }
+
+  final now = DateTime.now();
+  final startDate = DateTime(now.year, now.month, 1);
+  final normalizedStart = DateUtils.normalizeToMidnight(startDate);
+  
+  final repository = ref.read(diaryRepositoryProvider);
+  final entries = await repository.getDiaryEntriesForDateRange(
+    uid: uid,
+    startDate: normalizedStart,
+    endDate: now,
+  );
+
+  // Filter exercise entries only
+  final exerciseEntries = entries.where((e) => e.type == DiaryEntryType.exercise).toList();
+
+  // Aggregate workout data
+  double totalCaloriesBurned = 0.0;
+  double totalDurationMinutes = 0.0;
+  final exerciseNames = <String>{};
+
+  for (final entry in exerciseEntries) {
+    totalCaloriesBurned += entry.calories;
+    totalDurationMinutes += entry.durationMinutes ?? 0.0;
+    if (entry.exerciseName != null) {
+      exerciseNames.add(entry.exerciseName!);
+    }
+  }
+
+  return WorkoutStats(
+    totalCaloriesBurned: totalCaloriesBurned,
+    totalDurationMinutes: totalDurationMinutes,
+    workoutCount: exerciseEntries.length,
+    exerciseNames: exerciseNames.toList()..sort(),
+  );
+});
+
+// ============================================================================
+// STEPS STATISTICS PROVIDERS
+// ============================================================================
+
+/// Get steps statistics for today
+final todayStepsStatsProvider = FutureProvider<StepsStats>((ref) async {
+  final healthRepo = ref.read(healthRepositoryProvider);
+  
+  try {
+    final steps = await healthRepo.getTodaySteps();
+    
+    // TODO: Get step goal from profile or settings if available
+    const targetSteps = null; // No step goal configured yet
+    
+    return StepsStats(
+      totalSteps: steps,
+      targetSteps: targetSteps,
+    );
+  } catch (e) {
+    // Return 0 steps on error
+    return StepsStats(totalSteps: 0, targetSteps: null);
+  }
+});
+
+/// Get steps statistics for this week (last 7 days)
+final weekStepsStatsProvider = FutureProvider<StepsStats>((ref) async {
+  final healthRepo = ref.read(healthRepositoryProvider);
+  
+  try {
+    final now = DateTime.now();
+    final startDate = now.subtract(const Duration(days: 6));
+    final normalizedStart = DateUtils.normalizeToMidnight(startDate);
+    
+    final steps = await healthRepo.getStepsForDateRange(
+      startDate: normalizedStart,
+      endDate: now,
+    );
+    
+    // TODO: Get step goal from profile or settings if available
+    const targetSteps = null; // No step goal configured yet
+    final weeklyTarget = targetSteps != null ? targetSteps * 7 : null;
+    
+    return StepsStats(
+      totalSteps: steps,
+      targetSteps: weeklyTarget,
+    );
+  } catch (e) {
+    // Return 0 steps on error
+    return StepsStats(totalSteps: 0, targetSteps: null);
+  }
+});
+
+/// Get steps statistics for this month
+final monthStepsStatsProvider = FutureProvider<StepsStats>((ref) async {
+  final healthRepo = ref.read(healthRepositoryProvider);
+  
+  try {
+    final now = DateTime.now();
+    final startDate = DateTime(now.year, now.month, 1);
+    final normalizedStart = DateUtils.normalizeToMidnight(startDate);
+    
+    final steps = await healthRepo.getStepsForDateRange(
+      startDate: normalizedStart,
+      endDate: now,
+    );
+    
+    // TODO: Get step goal from profile or settings if available
+    const targetSteps = null; // No step goal configured yet
+    final daysInMonth = DateTime(now.year, now.month + 1, 0).day;
+    final monthlyTarget = targetSteps != null ? targetSteps * daysInMonth : null;
+    
+    return StepsStats(
+      totalSteps: steps,
+      targetSteps: monthlyTarget,
+    );
+  } catch (e) {
+    // Return 0 steps on error
+    return StepsStats(totalSteps: 0, targetSteps: null);
+  }
+});
+
+// ============================================================================
+// WEIGHT STATISTICS PROVIDERS
+// ============================================================================
+
+/// Get weight statistics for today
+final todayWeightStatsProvider = FutureProvider<WeightStats>((ref) async {
+  final uid = ref.watch(currentUserIdProvider);
+  if (uid == null) {
+    throw Exception('User not logged in');
+  }
+
+  try {
+    final repository = ref.read(weightRepositoryProvider);
+    final now = DateTime.now();
+    final today = DateUtils.normalizeToMidnight(now);
+    final yesterday = today.subtract(const Duration(days: 1));
+    
+    // Get today's weight entry
+    final todayWeights = await repository.getWeightHistory(
+      uid: uid,
+      startDate: today,
+      endDate: today,
+    );
+    
+    // Get yesterday's weight for comparison
+    final yesterdayWeights = await repository.getWeightHistory(
+      uid: uid,
+      startDate: yesterday,
+      endDate: yesterday,
+    );
+    
+    // Get recent weights for chart (last 7 days)
+    final recentWeightsStream = repository.watchRecentWeights(uid: uid, days: 7);
+    final recentWeights = await recentWeightsStream.first;
+    
+    final todayWeight = todayWeights.isNotEmpty ? todayWeights.last.weightKg : null;
+    final yesterdayWeight = yesterdayWeights.isNotEmpty ? yesterdayWeights.last.weightKg : null;
+    
+    // If no weight today, use latest weight from history
+    final latestWeight = todayWeight ?? (recentWeights.isNotEmpty ? recentWeights.last.weightKg : null);
+    
+    final weightHistory = recentWeights
+        .map((entry) => WeightPoint(
+              date: entry.date,
+              weight: entry.weightKg,
+            ))
+        .toList();
+
+    // Get target weight from profile
+    final profileAsync = ref.read(currentUserProfileProvider);
+    final targetWeight = profileAsync.maybeWhen(
+      data: (profile) => profile?.targetWeight,
+      orElse: () => null,
+    );
+
+    return WeightStats(
+      latestWeight: latestWeight,
+      earliestWeight: recentWeights.isNotEmpty ? recentWeights.first.weightKg : null,
+      weightChange: todayWeight != null && yesterdayWeight != null
+          ? todayWeight - yesterdayWeight
+          : null,
+      entryCount: todayWeights.length,
+      weightHistory: weightHistory,
+      targetWeight: targetWeight,
+      previousPeriodWeight: yesterdayWeight,
+    );
+  } catch (e) {
+    throw Exception('Không thể tải dữ liệu cân nặng hôm nay: ${e.toString()}');
+  }
+});
+
+/// Get weight statistics for this week (from start of week to today)
+final weekWeightStatsProvider = FutureProvider<WeightStats>((ref) async {
+  final uid = ref.watch(currentUserIdProvider);
+  if (uid == null) {
+    throw Exception('User not logged in');
+  }
+
+  try {
+    final repository = ref.read(weightRepositoryProvider);
+    final now = DateTime.now();
+    
+    // Calculate start of week (Monday = 1, Sunday = 7)
+    final weekday = now.weekday;
+    final startOfWeek = DateUtils.normalizeToMidnight(now.subtract(Duration(days: weekday - 1)));
+    
+    // Get last week's end date for comparison
+    final lastWeekEnd = startOfWeek.subtract(const Duration(days: 1));
+    final lastWeekStart = lastWeekEnd.subtract(const Duration(days: 6));
+    
+    // Get weights for this week
+    final weekWeights = await repository.getWeightHistory(
+      uid: uid,
+      startDate: startOfWeek,
+      endDate: now,
+    );
+    
+    // Get last week's weights for comparison
+    final lastWeekWeights = await repository.getWeightHistory(
+      uid: uid,
+      startDate: lastWeekStart,
+      endDate: lastWeekEnd,
+    );
+    
+    if (weekWeights.isEmpty) {
+      return WeightStats(
+        entryCount: 0,
+        weightHistory: [],
+        targetWeight: null,
+        previousPeriodWeight: lastWeekWeights.isNotEmpty ? lastWeekWeights.last.weightKg : null,
+      );
+    }
+
+    final latestWeight = weekWeights.last.weightKg;
+    final earliestWeight = weekWeights.first.weightKg;
+    final weightChange = latestWeight - earliestWeight;
+    final lastWeekEndWeight = lastWeekWeights.isNotEmpty ? lastWeekWeights.last.weightKg : null;
+
+    final weightHistory = weekWeights
+        .map((entry) => WeightPoint(
+              date: entry.date,
+              weight: entry.weightKg,
+            ))
+        .toList();
+
+    // Get target weight from profile
+    final profileAsync = ref.read(currentUserProfileProvider);
+    final targetWeight = profileAsync.maybeWhen(
+      data: (profile) => profile?.targetWeight,
+      orElse: () => null,
+    );
+
+    return WeightStats(
+      latestWeight: latestWeight,
+      earliestWeight: earliestWeight,
+      weightChange: weightChange,
+      entryCount: weekWeights.length,
+      weightHistory: weightHistory,
+      targetWeight: targetWeight,
+      previousPeriodWeight: lastWeekEndWeight,
+    );
+  } catch (e) {
+    throw Exception('Không thể tải dữ liệu cân nặng tuần này: ${e.toString()}');
+  }
+});
+
+/// Get weight statistics for this month (from start of month to today)
+final monthWeightStatsProvider = FutureProvider<WeightStats>((ref) async {
+  final uid = ref.watch(currentUserIdProvider);
+  if (uid == null) {
+    throw Exception('User not logged in');
+  }
+
+  try {
+    final repository = ref.read(weightRepositoryProvider);
+    final now = DateTime.now();
+    final startOfMonth = DateTime(now.year, now.month, 1);
+    final normalizedStart = DateUtils.normalizeToMidnight(startOfMonth);
+    
+    // Get last month's end date for comparison
+    final lastMonthEnd = normalizedStart.subtract(const Duration(days: 1));
+    final lastMonthStart = DateTime(lastMonthEnd.year, lastMonthEnd.month, 1);
+    
+    // Get weights for this month
+    final monthWeights = await repository.getWeightHistory(
+      uid: uid,
+      startDate: normalizedStart,
+      endDate: now,
+    );
+    
+    // Get last month's weights for comparison
+    final lastMonthWeights = await repository.getWeightHistory(
+      uid: uid,
+      startDate: lastMonthStart,
+      endDate: lastMonthEnd,
+    );
+    
+    if (monthWeights.isEmpty) {
+      return WeightStats(
+        entryCount: 0,
+        weightHistory: [],
+        targetWeight: null,
+        previousPeriodWeight: lastMonthWeights.isNotEmpty ? lastMonthWeights.last.weightKg : null,
+      );
+    }
+
+    final latestWeight = monthWeights.last.weightKg;
+    final earliestWeight = monthWeights.first.weightKg;
+    final weightChange = latestWeight - earliestWeight;
+    final lastMonthEndWeight = lastMonthWeights.isNotEmpty ? lastMonthWeights.last.weightKg : null;
+
+    final weightHistory = monthWeights
+        .map((entry) => WeightPoint(
+              date: entry.date,
+              weight: entry.weightKg,
+            ))
+        .toList();
+
+    // Get target weight from profile
+    final profileAsync = ref.read(currentUserProfileProvider);
+    final targetWeight = profileAsync.maybeWhen(
+      data: (profile) => profile?.targetWeight,
+      orElse: () => null,
+    );
+
+    return WeightStats(
+      latestWeight: latestWeight,
+      earliestWeight: earliestWeight,
+      weightChange: weightChange,
+      entryCount: monthWeights.length,
+      weightHistory: weightHistory,
+      targetWeight: targetWeight,
+      previousPeriodWeight: lastMonthEndWeight,
+    );
+  } catch (e) {
+    throw Exception('Không thể tải dữ liệu cân nặng tháng này: ${e.toString()}');
+  }
+});
+

--- a/lib/features/onboarding/domain/profile_model.dart
+++ b/lib/features/onboarding/domain/profile_model.dart
@@ -267,6 +267,64 @@ class ProfileModel {
     return map;
   }
 
+  /// Get human-readable gender label in Vietnamese
+  String get genderLabel {
+    switch (gender?.toLowerCase()) {
+      case 'male':
+        return 'Nam';
+      case 'female':
+        return 'Nữ';
+      case 'other':
+        return 'Khác';
+      default:
+        return gender ?? '-';
+    }
+  }
+
+  /// Get human-readable activity level label in Vietnamese
+  String get activityLevelLabel {
+    switch (activityLevel?.toLowerCase()) {
+      case 'sedentary':
+        return 'Không tập luyện/Ít vận động';
+      case 'light':
+        return 'Vận động nhẹ nhàng';
+      case 'moderate':
+        return 'Chăm chỉ luyện tập';
+      case 'very_active':
+        return 'Rất năng động / Cực kỳ năng động';
+      default:
+        return activityLevel ?? '-';
+    }
+  }
+
+  /// Get human-readable goal type label in Vietnamese
+  String get goalTypeLabel {
+    switch (goalType?.toLowerCase()) {
+      case 'lose':
+        return 'Giảm cân';
+      case 'maintain':
+        return 'Duy trì';
+      case 'gain':
+        return 'Tăng cân';
+      default:
+        return goalType ?? '-';
+    }
+  }
+
+  /// Get formatted birth date string (dd/MM/yyyy)
+  String get birthDateString {
+    if (dobIso == null) return '-';
+    try {
+      final date = DateTime.parse(dobIso!);
+      final day = date.day.toString().padLeft(2, '0');
+      final month = date.month.toString().padLeft(2, '0');
+      final year = date.year.toString();
+      return '$day/$month/$year';
+    } catch (_) {
+      return dobIso ?? '-';
+    }
+  }
+
   /// Create a copy of this ProfileModel with updated fields
   ProfileModel copyWith({
     String? nickname,


### PR DESCRIPTION
## Summary

This PR updates the account/profile module:

- Enable editing display name from the Account screen and sync it with Firestore `users/{uid}.displayName`.
- Wire **Personal Info** screen to existing profile data (gender, age, height, current weight, activity level).
- Wire **My Goals** / nutrition goals section to Firestore targets (daily calories + macro ratios).
- Make sure profile form shows current values and saves changes back to Firestore with proper validation.
- Add Vietnamese copy for all new labels / messages to keep UX consistent.

## Technical details

- Reused existing `ProfileRepository` / `UserProfile` models instead of creating new ones.
- Updated providers to:
  - Load profile once and expose it to Account + edit screens.
  - Refresh profile after a successful update (so Account screen shows new data immediately).
- Updated `firestore.indexes.json`:
  - Added composite indexes for `weights` and `diaryEntries` collections to support new reports & queries.

## Screens / UX

- Account screen:
  - Shows avatar, editable display name, email, and progress towards weight goal.
  - Buttons:
    - **Chỉnh sửa hồ sơ** → opens personal info form.
    - **Tùy chỉnh mục tiêu** → opens nutrition / goals screen.

- Edit profile screen:
  - Gender, age, height, current weight.
  - Goal type & target weight.
  - Activity level.
  - "Lưu" button is disabled while submitting and shows loading state.

## Testing

- [x] Existing user with profile → Account screen loads profile + goals correctly.
- [x] Change display name → Account screen updates immediately, data is persisted in Firestore.
- [x] Update profile fields → reopen screen and values are still correct.
- [x] Update goals → nutrition goal widget on Account screen shows new target.
- [x] Start app logged out → no regressions in auth / onboarding flow.
- [x] No Firestore permission errors in debug logs.

## Notes

If you want, I can split profile/goals + indexes into separate PRs later, but right now everything works together as one feature.
